### PR TITLE
fix: `_findParent` is going through the whole widget tree

### DIFF
--- a/lib/src/stateless.dart
+++ b/lib/src/stateless.dart
@@ -122,17 +122,16 @@ class _StatelessState<T extends _StateWidget> extends State<T> {
   }
 
   Stateless _findParent(BuildContext context) {
-    late Stateless parent;
+    late Stateless ancestor;
     context.visitAncestorElements((element) {
       if (element is _StatelessElement) {
         this.element = element;
-
-        parent = element.widget as Stateless;
-        return true;
+        ancestor = element.widget as Stateless;
+        return false;
       }
-      return false;
+      return true;
     });
-    return parent;
+    return ancestor;
   }
 }
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

`_findParent` was going through the whole widget tree, turning it into `O(N)` while it should have been `O(1)`.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
